### PR TITLE
Added the file descriptor set library (Cygwin bug)

### DIFF
--- a/README.linux
+++ b/README.linux
@@ -98,7 +98,7 @@ make install
 This will install Titan into  /home/<user id>/titan.core/Install
 
 
-7. Optionally , run function/regression tests
+7. Optionally, run function/regression tests
 
 cd /home/<user id>/titan.core/function_test
 

--- a/core/Event_Handler.hh
+++ b/core/Event_Handler.hh
@@ -9,6 +9,7 @@
 #define EVENT_HANDLER_HH
 
 #include "Types.h"
+#include <sys/select.h>
 
 /**
 * The definitions in this header file are needed for TITAN.


### PR DESCRIPTION
As explained in this thread: https://www.eclipse.org/forums/index.php/t/1075026/
On certain Cygwin configurations, it's impossible to compile without this line.