### PR TITLE
Added the file descriptor set library (Cygwin bug)

### DIFF
--- a/core/Event_Handler.hh
+++ b/core/Event_Handler.hh
@@ -9,6 +9,7 @@
 #define EVENT_HANDLER_HH
 
 #include "Types.h"
+
 #include <sys/select.h>
 
 /**

--- a/core/Event_Handler.hh
+++ b/core/Event_Handler.hh
@@ -9,7 +9,6 @@
 #define EVENT_HANDLER_HH
 
 #include "Types.h"
-
 #include <sys/select.h>
 
 /**


### PR DESCRIPTION
I created a little chaos until I found out how to use the signatures ("signed-off by...") and I am sorry for that.

To copy the description from the other pull request:
As explained in this thread: https://www.eclipse.org/forums/index.php/t/1075026/
On certain Cygwin configurations, it's impossible to compile without this line.