### PR TITLE
Removed compiler fatal errors generated by templates initialized with…

### DIFF
--- a/compiler2/ttcn3/TtcnTemplate.cc
+++ b/compiler2/ttcn3/TtcnTemplate.cc
@@ -3053,8 +3053,9 @@ end:
       warning("Don't know how to init PERMUT");
       str = mputprintf(str, "/* FIXME: PERMUT goes here, name=%s*/\n", name);
       break;
-    case TEMPLATE_ERROR:
     case TEMPLATE_NOTUSED:
+      break;
+    case TEMPLATE_ERROR:
       // "default"
       FATAL_ERROR("Template::generate_code_init()");
     }
@@ -4536,6 +4537,7 @@ compile_time:
     case OSTR_PATTERN:
     case CSTR_PATTERN:
     case USTR_PATTERN:
+    case TEMPLATE_NOTUSED:
       return false;
     case TEMPLATE_LIST:
       // temporary reference is needed if the template has at least one
@@ -4564,7 +4566,6 @@ compile_time:
     case SUBSET_MATCH:
       return true;
     case TEMPLATE_ERROR:
-    case TEMPLATE_NOTUSED:
       FATAL_ERROR("Template::needs_temp_ref()");
     case PERMUTATION_MATCH:
       // FIXME
@@ -4586,6 +4587,7 @@ compile_time:
     case OSTR_PATTERN:
     case CSTR_PATTERN:
     case USTR_PATTERN:
+    case TEMPLATE_NOTUSED:
       return true;
     case SPECIFIC_VALUE:
       return u.specific_value->has_single_expr();

--- a/compiler2/ttcn3/compiler.y
+++ b/compiler2/ttcn3/compiler.y
@@ -5556,7 +5556,7 @@ DisconnectStatement: // 335
   }
 | DisconnectKeyword SingleOrMultiConnectionSpec
   {
-    if ($2.compref1 && $2.portref1 && $2.compref1 && $2.compref2) {
+    if ($2.portref1 && $2.portref2 && $2.compref1 && $2.compref2) {
       $$ = new Statement(Statement::S_DISCONNECT,
 	$2.compref1, $2.portref1, $2.compref2, $2.portref2);
     } else {


### PR DESCRIPTION
… the not used '-' symbol (artf729766, artf729733, artf724150, artf729731)

Change-Id: I07cac7957cd2f117717ec12253e3daf5f49c4695
Signed-off-by: Botond Baranyi <botond.baranyi@ericsson.com>