### PR TITLE
Fix generation of debug information for unused shadow parameters

### DIFF
--- a/compiler2/DebuggerStuff.cc
+++ b/compiler2/DebuggerStuff.cc
@@ -198,6 +198,10 @@ char* generate_code_debugger_add_var(char* str, Common::Assignment* var_ass,
     eval = var_ass->get_eval_type();
     Ttcn::FormalPar* fpar = dynamic_cast<Ttcn::FormalPar*>(var_ass);
     is_constant = fpar == NULL || !fpar->get_used_as_lvalue();
+    if(!fpar->need_generate_shadow_object()) {
+      // detect if the shadow object was skipped as not used
+      return str ? str : memptystr();
+    }
     break; }
   case Common::Assignment::A_CONST:
   case Common::Assignment::A_EXT_CONST:

--- a/compiler2/ttcn3/AST_ttcn3.cc
+++ b/compiler2/ttcn3/AST_ttcn3.cc
@@ -7824,9 +7824,6 @@ namespace Ttcn {
     // assemble the function body first (this also determines which parameters
     // are never used)
     char* body = create_location_object(memptystr(), "ALTSTEP", dispname_str);
-    if (debugger_active) {
-      body = generate_code_debugger_function_init(body, this);
-    }
     body = sb->generate_code(body, target->header.global_vars,
       target->source.global_vars);
     body = ags->generate_code_altstep(body, target->header.global_vars,
@@ -7844,16 +7841,22 @@ namespace Ttcn {
     // (this needs be done after the body is generated, so it to knows which 
     // parameters are never used)
     char* shadow_objects = fp_list->generate_shadow_objects(memptystr());
+
+    char* dbg = memptystr();
+    if (debugger_active) {
+      dbg = generate_code_debugger_function_init(dbg, this);
+    }
     
     // function for altstep instance: body
     target->source.function_bodies = mputprintf(target->source.function_bodies,
       "alt_status %s_instance(%s)\n"
       "{\n"
-      "%s%s"
-      "}\n\n", genname_str, formal_par_list, shadow_objects, body);
+      "%s%s%s"
+      "}\n\n", genname_str, formal_par_list, shadow_objects, dbg, body);
     Free(formal_par_list);
     Free(shadow_objects);
     Free(body);
+    Free(dbg);
 
     char *actual_par_list =
       fp_list->generate_code_actual_parlist(memptystr(), "");
@@ -9248,11 +9251,17 @@ namespace Ttcn {
     return str;
   }
 
+  bool  FormalPar::need_generate_shadow_object() const
+  {
+    return ((used_as_lvalue || (use_runtime_2 && usage_found &&
+            my_parlist->get_my_def()->get_asstype() == Definition::A_ALTSTEP)) && 
+            eval == NORMAL_EVAL)
+           && (asstype == A_PAR_VAL_IN || asstype == A_PAR_TEMPL_IN);
+  }
+
   char *FormalPar::generate_shadow_object(char *str) const
   {
-    if ((used_as_lvalue || (use_runtime_2 && usage_found &&
-        my_parlist->get_my_def()->get_asstype() == Definition::A_ALTSTEP))
-        && eval == NORMAL_EVAL) {
+    if (need_generate_shadow_object()) {
       const string& t_genname = get_genname();
       const char *genname_str = t_genname.c_str();
       const char *name_str = id->get_name().c_str();

--- a/compiler2/ttcn3/AST_ttcn3.hh
+++ b/compiler2/ttcn3/AST_ttcn3.hh
@@ -1825,6 +1825,7 @@ namespace Ttcn {
      * parameter when necessary. It is used when the value of an 'in' value or
      * template parameter is overwritten within the function body. */
     char *generate_shadow_object(char *str) const;
+    bool  need_generate_shadow_object() const;
    /** Generates a C++ statement that calls a function that sets the parameter unbound
      *  It is used when the value of an 'out' value  */
     char *generate_code_set_unbound(char *str) const;


### PR DESCRIPTION
Titan doesn't generate shadow parameter objects for unused parameters in ALTSTEPs. By the way, when generation of debug information is enabled, these objects are used for debug purposes.
Provided patch fixes this issue.