### PR TITLE
fix linking TTCN3 programs on Ubuntu 18.04

### DIFF
--- a/compiler2/titanver
+++ b/compiler2/titanver
@@ -69,6 +69,7 @@ my $obj = '?';
 sub match_comment() {
     if (length($comment)) {
         ($found_ver) = $comment =~ /((GCC|Clang): \([^)]*\) \d\.\d+(?:\.\d+)?)/;
+        $found_ver =~ s/ \([^)]*\)//;
 	if ($found_ver) {
           print "$compiler version was $found_ver for $obj\n" if $v;
 


### PR DESCRIPTION
Linking TTCN3 programs on an up-to-date Ubuntu 18.04 system failed.

The official Ubuntu 18.04 eclipse-titan package is installed:

$ apt list -a eclipse-titan
Listing... Done
eclipse-titan/bionic,now 6.3.1-1build1 amd64 [installed]

The ttcn3 library contains "GCC: (GNU) 7.3.0" in its .titan section:

$ objdump -s -j .titan /usr/lib/titan/libttcn3-dynamic.so | tail
 64f1f0 00000000 00000000 00000000 00000000  ................
 64f200 54495441 4e3a2036 30333031 20504c41  TITAN: 60301 PLA
 64f210 54464f52 4d3a204c 494e5558 20474343  TFORM: LINUX GCC
 64f220 3a202847 4e552920 372e332e 3000      : (GNU) 7.3.0.

However, the installed compiler version puts a different string
into the .comment section of newly compiled object files:
"GCC: (Ubuntu 7.3.0-16ubuntu3) 7.3.0"

Because of this mismatch titanver reports an error during the final link stage:
"""
Error! All object files should be compiled with the same compiler version.
The following Compiler versions were detected: GCC: (Ubuntu 7.3.0-16ubuntu3) 7.3.0, GCC: (GNU) 7.3.0
Run make clean and make to recompile the project if the version of the compiler changed recently. at /usr/bin/titanver line 113.
"""

The TTCN3 shared library was not compiled by me. It was compiled by
Ubuntu packagers at some point in time, and installed via 'apt install'.
Some time later on Ubuntu's gcc package was updated. The compiler's version
number remained unchanged but the comment string was changed to reflect
the Ubuntu package's patch level.

In this situation, linking my own TTCN3 modules against Ubuntu's
libttcn3 no longer works.

It is common practice in Linux distributions to avoid recompiling packages
unless it is absolutely necessary. So we cannot expect Ubuntu to provide a
freshly compiled ecipse-titan package whenever the gcc package is updated.

This patch makes titanver ignore parts of the compiler version string
within parentheses and fixes this problem for me.

Signed-off-by: Stefan Sperling <ssperling@sysmocom.de>