### PR TITLE
log result when TC finishes with verdict inconc

### DIFF
--- a/loggerplugins/JUnitLogger2/JUnitLogger2.cc
+++ b/loggerplugins/JUnitLogger2/JUnitLogger2.cc
@@ -236,6 +236,13 @@ void TestCase::writeTestCase(FILE* file_stream_) const{
       fprintf(file_stream_, "    <error type='DTE'>%s</error>\n", dte_reason.data());
       fprintf(file_stream_, "  </testcase>\n");
       break; }
+    case Inconc:  {
+      fprintf(file_stream_, "  <testcase classname='%s' name='%s' time='%f'>\n", module_name.data(), tc_name.data(), time);
+      fprintf(file_stream_, "    <failure type='inconclusive-verdict'>%s\n", reason.data());
+      fprintf(file_stream_, "%s\n", stack_trace.data());
+      fprintf(file_stream_, "    </failure>\n");
+      fprintf(file_stream_, "  </testcase>\n");
+      break; }
     default: 
       fprintf(file_stream_, "  <testcase classname='%s' name='%s' time='%f'/>\n", module_name.data(), tc_name.data(), time);
       break;


### PR DESCRIPTION
when a TC finished with verdict inconc the JUnitLogger was not logging the result and so the TC in the generated XML could have been interpreted as passed (happens in Jenkins' JUnit test result analyzer plugin)