### PR TITLE
Bugfix: bug 568716

### DIFF
--- a/compiler2/ttcn3/Ttcnstuff.cc
+++ b/compiler2/ttcn3/Ttcnstuff.cc
@@ -3472,6 +3472,11 @@ namespace Ttcn {
                 local_def->error("Cannot override final method `%s'",
                   base_def->get_fullname().c_str());
               }
+              else if (base_func->get_visibility() == PUBLIC && local_func->is_identical(base_func)
+            		   && local_func->get_visibility() != PUBLIC) {
+            	local_def->error("Public methods can be overridden only by public methods `%s'",
+            	  local_id.get_dispname().c_str());
+              }
               break; }
             default:
               local_def->error("%s shadows inherited member `%s'",


### PR DESCRIPTION
OOP_public methods shall be overridden only by public methods (bug
568716)

Signed-off-by: Adam Knapp <knappadam5@gmail.com>